### PR TITLE
Enable PM agent to receive local repository clones on startup

### DIFF
--- a/src/cli/src/commands/start.ts
+++ b/src/cli/src/commands/start.ts
@@ -42,8 +42,8 @@ export async function start(role: string): Promise<void> {
     console.log(chalk.dim(`Copied SSH key into .minions/${role}/`));
   }
 
-  // Determine repos for this role (PM gets none, everyone else gets all)
-  const repos = agentRole === 'pm' ? [] : settings.repos;
+  // Determine repos for this role
+  const repos = settings.repos;
   const allRoles = Object.keys(settings.roles) as AgentRole[];
 
   // Clone repos and configure each one individually

--- a/src/cli/src/templates/pm.md
+++ b/src/cli/src/templates/pm.md
@@ -31,8 +31,8 @@ gh issue list -R <owner/repo> --label "role:<role>"
 
 ## Tools & Access
 - **GitHub CLI (`gh`)**: Your primary tool. Use it for all GitHub operations.
-- **Repository access**: None. You do NOT have direct file access to any repositories.
-- You operate entirely through the `gh` CLI.
+- **Repository access**: Read-only access to local repository clones for reading documentation and understanding codebase structure.
+- You can read files using the Read tool, but cannot modify them.
 
 ## Working Directory Guidelines
 - **Always stay within your minion working directory** (specific path will be set when the agent starts)
@@ -41,7 +41,7 @@ gh issue list -R <owner/repo> --label "role:<role>"
 - Each Bash command runs in a fresh shell, so chain commands with `&&` when needed
 
 ## Constraints
-- Do NOT attempt to read or modify files in any repository
+- Do NOT modify files in any repository (read-only access is allowed)
 - Do NOT create branches, commits, or pull requests
 - Focus exclusively on project visibility, prioritization, and coordination
 


### PR DESCRIPTION
## Summary
Enables the PM (Product Manager) agent to have read-only access to local repository clones on startup. This allows PM to read project documentation, examine codebase structure, and provide better context when coordinating work.

## Changes
- **src/cli/src/commands/start.ts**: Removed PM exclusion from repository cloning logic
- **src/cli/src/templates/pm.md**: Updated to reflect read-only repository access and allow reading files

## Acceptance Criteria
- [x] PM agent receives local repository clones on startup
- [x] Repository clones are placed in `.minions/pm/<repo-path>/`
- [x] PM can read files from the repository
- [x] Existing PM constraints remain (no writing/modifying files, no branches/commits/PRs)

Closes #4