### PR TITLE
Add CLI configuration to map minion roles to Claude models

### DIFF
--- a/src/cli/src/commands/init.ts
+++ b/src/cli/src/commands/init.ts
@@ -131,10 +131,20 @@ async function promptForSettings(): Promise<Settings> {
     validate: (answer: string[]) => answer.length > 0 || 'You must select at least one role.',
   }]);
 
-  // Build roles config object
+  // Build roles config object with recommended models
+  const RECOMMENDED_MODELS: Record<AgentRole, 'opus' | 'sonnet' | 'haiku'> = {
+    'cao': 'opus',          // Architecture and planning needs deep reasoning
+    'pm': 'sonnet',         // Balanced for coordination and triage
+    'fe-engineer': 'sonnet', // Balanced for implementation
+    'be-engineer': 'sonnet', // Balanced for implementation
+    'qa': 'haiku',          // Faster execution for testing
+  };
+
   const roles: Partial<Record<AgentRole, RoleConfig>> = {};
   for (const role of selectedRoles) {
-    roles[role as AgentRole] = {};
+    roles[role as AgentRole] = {
+      model: RECOMMENDED_MODELS[role as AgentRole],
+    };
   }
 
   // Prompt for SSH key path (optional)

--- a/src/cli/src/commands/start.ts
+++ b/src/cli/src/commands/start.ts
@@ -116,6 +116,12 @@ export async function start(role: string): Promise<void> {
     claudeArgs.push('--dangerously-skip-permissions');
   }
 
+  // Pass model configuration if specified
+  const roleConfig = settings.roles[agentRole];
+  if (roleConfig?.model) {
+    claudeArgs.push('--model', roleConfig.model);
+  }
+
   // Launch claude
   console.log(chalk.bold.green(`\nStarting ${role} agent...`));
   console.log(chalk.dim(`Working directory: ${roleDir}`));

--- a/src/cli/src/lib/schemas.ts
+++ b/src/cli/src/lib/schemas.ts
@@ -7,9 +7,12 @@ export const RepoSchema = z.object({
   path: z.string(),
 });
 
+export const ClaudeModelSchema = z.enum(['opus', 'sonnet', 'haiku']);
+
 export const RoleConfigSchema = z.object({
   systemPrompt: z.string().optional(),
   systemPromptFile: z.string().optional(),
+  model: ClaudeModelSchema.optional(),
 }).refine(
   data => !(data.systemPrompt && data.systemPromptFile),
   { message: 'Cannot specify both systemPrompt and systemPromptFile' }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,9 +6,12 @@ export interface Repo {
   path: string;
 }
 
+export type ClaudeModel = 'opus' | 'sonnet' | 'haiku';
+
 export interface RoleConfig {
   systemPrompt?: string;
   systemPromptFile?: string;
+  model?: ClaudeModel;
 }
 
 export interface Settings {


### PR DESCRIPTION
## Summary
Enables configuration of which Claude model (opus/sonnet/haiku) each minion role uses, allowing optimization of cost vs performance based on role complexity.

## Changes
- **src/core/types.ts**: Added `ClaudeModel` type and `model` field to `RoleConfig`
- **src/cli/src/lib/schemas.ts**: Added Zod validation for model configuration
- **src/cli/src/commands/start.ts**: Pass `--model` flag to Claude CLI when starting agents
- **src/cli/src/commands/init.ts**: Include recommended models when creating roles

## Recommended Defaults
- **cao**: opus (architecture/planning needs deep reasoning)
- **pm**: sonnet (balanced for coordination and triage)
- **fe-engineer**: sonnet (balanced for implementation)
- **be-engineer**: sonnet (balanced for implementation)
- **qa**: haiku (faster execution for testing/verification)

## Example Configuration
```json
{
  "mode": "ask",
  "repos": [...],
  "roles": {
    "cao": {
      "model": "opus"
    },
    "be-engineer": {
      "model": "sonnet"
    },
    "qa": {
      "model": "haiku"
    }
  }
}
```

## Acceptance Criteria
- [x] ClaudeModel type added to src/core/types.ts
- [x] RoleConfig interface includes optional model field
- [x] Zod schema validates model values (opus/sonnet/haiku only)
- [x] Start command passes --model flag to Claude CLI when configured
- [x] Model configuration is optional (backward compatible)
- [x] Init command includes recommended models per role

## Notes
- Model configuration is **optional** - if not specified, Claude CLI uses its default
- This change is fully backward compatible - existing minions.json files without model config will continue to work

Closes #3