### PR TITLE
Build WebSocket server infrastructure for agent communication

### DIFF
--- a/src/cli/src/commands/server.ts
+++ b/src/cli/src/commands/server.ts
@@ -1,5 +1,20 @@
 import chalk from 'chalk';
+import { MinionsServer } from '../../../server/src/index.js';
+import { loadSettings, getWorkspaceRoot } from '../lib/config.js';
 
 export async function server(): Promise<void> {
-  console.log(chalk.yellow('minions server - not yet implemented (Task 2.5)'));
+  try {
+    const workspaceRoot = getWorkspaceRoot();
+    const settings = loadSettings(workspaceRoot);
+
+    const port = settings.serverPort || 3000;
+    const srv = new MinionsServer();
+
+    console.log(chalk.green(`Starting Minions server on port ${port}...`));
+    srv.start(port);
+  } catch (error) {
+    console.error(chalk.red('Failed to start server:'));
+    console.error(error instanceof Error ? error.message : 'Unknown error');
+    process.exit(1);
+  }
 }

--- a/src/cli/src/lib/schemas.ts
+++ b/src/cli/src/lib/schemas.ts
@@ -23,4 +23,5 @@ export const SettingsSchema = z.object({
   repos: z.array(RepoSchema),
   roles: z.record(z.enum(VALID_ROLES), RoleConfigSchema).default({}),
   ssh: z.string().optional(),
+  serverPort: z.number().optional(),
 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,6 +19,7 @@ export interface Settings {
   repos: Repo[];
   roles: Partial<Record<AgentRole, RoleConfig>>;
   ssh?: string;
+  serverPort?: number;
 }
 
 export type AgentRole = 'pm' | 'cao' | 'fe-engineer' | 'be-engineer' | 'qa';

--- a/src/server/src/MessageRouter.ts
+++ b/src/server/src/MessageRouter.ts
@@ -1,0 +1,61 @@
+import type { Message } from '../../core/messages.js';
+import type { WebSocket } from 'ws';
+import { validateMessage } from './schemas.js';
+
+export interface AgentConnection {
+  ws: WebSocket;
+  role: string;
+  status: 'online' | 'offline' | 'working';
+  connectedAt: string;
+}
+
+export class MessageRouter {
+  constructor(private clients: Map<string, AgentConnection>) {}
+
+  route(rawMessage: unknown, senderId: string) {
+    try {
+      // Validate message
+      const message = validateMessage(rawMessage);
+
+      // Route based on message type and 'to' field
+      if (message.type === 'chat' && message.to) {
+        // Unicast to specific agent
+        this.sendToAgent(message.to, message);
+      } else {
+        // Broadcast to all agents except sender
+        this.broadcast(message, senderId);
+      }
+    } catch (error) {
+      console.error('Invalid message:', error);
+      // Send error back to sender
+      const senderConn = this.clients.get(senderId);
+      if (senderConn) {
+        senderConn.ws.send(JSON.stringify({
+          type: 'system',
+          content: `Invalid message: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          timestamp: new Date().toISOString(),
+        }));
+      }
+    }
+  }
+
+  private sendToAgent(agentRole: string, message: Message) {
+    // Find agent by role and send
+    for (const [id, conn] of this.clients.entries()) {
+      if (conn.role === agentRole && conn.ws.readyState === 1) { // 1 = OPEN
+        conn.ws.send(JSON.stringify(message));
+        return;
+      }
+    }
+    console.warn(`Agent with role '${agentRole}' not found or not connected`);
+  }
+
+  private broadcast(message: Message, excludeId: string) {
+    // Send to all connected clients except sender
+    for (const [id, conn] of this.clients.entries()) {
+      if (id !== excludeId && conn.ws.readyState === 1) { // 1 = OPEN
+        conn.ws.send(JSON.stringify(message));
+      }
+    }
+  }
+}

--- a/src/server/src/WebSocketServer.ts
+++ b/src/server/src/WebSocketServer.ts
@@ -1,0 +1,85 @@
+import { WebSocketServer as WSServer, WebSocket } from 'ws';
+import type { Server } from 'http';
+import { MessageRouter, type AgentConnection } from './MessageRouter.js';
+import { v4 as uuidv4 } from 'uuid';
+
+export class WebSocketServer {
+  private wss: WSServer;
+  private clients: Map<string, AgentConnection>;
+  private router: MessageRouter;
+
+  constructor(server: Server) {
+    this.wss = new WSServer({ server, path: '/ws' });
+    this.clients = new Map();
+    this.router = new MessageRouter(this.clients);
+
+    this.wss.on('connection', (ws) => this.handleConnection(ws));
+  }
+
+  private handleConnection(ws: WebSocket) {
+    const clientId = uuidv4();
+
+    // Initialize connection with default values
+    const connection: AgentConnection = {
+      ws,
+      role: 'unknown',
+      status: 'online',
+      connectedAt: new Date().toISOString(),
+    };
+
+    this.clients.set(clientId, connection);
+    console.log(`Client connected: ${clientId}`);
+
+    // Set up message handler
+    ws.on('message', (data) => {
+      try {
+        const message = JSON.parse(data.toString());
+
+        // Update connection metadata if it's an agent_status message
+        if (message.type === 'agent_status') {
+          connection.role = message.role;
+          connection.status = message.status;
+          connection.connectedAt = message.timestamp || connection.connectedAt;
+          console.log(`Agent registered: ${message.role} (${clientId})`);
+        }
+
+        // Route the message
+        this.router.route(message, clientId);
+      } catch (error) {
+        console.error('Error handling message:', error);
+        ws.send(JSON.stringify({
+          type: 'system',
+          content: 'Error processing message',
+          timestamp: new Date().toISOString(),
+        }));
+      }
+    });
+
+    // Set up disconnect handler
+    ws.on('close', () => {
+      console.log(`Client disconnected: ${clientId} (role: ${connection.role})`);
+      this.clients.delete(clientId);
+    });
+
+    // Set up error handler
+    ws.on('error', (error) => {
+      console.error(`WebSocket error for ${clientId}:`, error);
+    });
+
+    // Send welcome message
+    ws.send(JSON.stringify({
+      type: 'system',
+      content: 'Connected to Minions server',
+      timestamp: new Date().toISOString(),
+    }));
+  }
+
+  getConnectedAgents() {
+    return Array.from(this.clients.entries()).map(([id, conn]) => ({
+      id,
+      role: conn.role,
+      status: conn.status,
+      connectedAt: conn.connectedAt,
+    }));
+  }
+}

--- a/src/server/src/index.ts
+++ b/src/server/src/index.ts
@@ -1,2 +1,40 @@
-// Server entry point - placeholder for Phase 2
-console.log('minions server - not yet implemented');
+import express from 'express';
+import { createServer } from 'http';
+import { WebSocketServer } from './WebSocketServer.js';
+
+export class MinionsServer {
+  private app: express.Application;
+  private server: ReturnType<typeof createServer>;
+  private wss: WebSocketServer;
+
+  constructor() {
+    this.app = express();
+    this.server = createServer(this.app);
+    this.wss = new WebSocketServer(this.server);
+
+    this.setupRoutes();
+  }
+
+  private setupRoutes() {
+    // Health check endpoint
+    this.app.get('/api/health', (req, res) => {
+      res.json({ status: 'ok' });
+    });
+
+    // Get connected agents
+    this.app.get('/api/agents', (req, res) => {
+      const agents = this.wss.getConnectedAgents();
+      res.json({ agents });
+    });
+  }
+
+  start(port: number) {
+    this.server.listen(port, () => {
+      console.log(`Minions server running on port ${port}`);
+      console.log(`WebSocket endpoint: ws://localhost:${port}/ws`);
+      console.log(`API endpoints:`);
+      console.log(`  - GET http://localhost:${port}/api/health`);
+      console.log(`  - GET http://localhost:${port}/api/agents`);
+    });
+  }
+}

--- a/src/server/src/schemas.ts
+++ b/src/server/src/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+export const ChatMessageSchema = z.object({
+  type: z.literal('chat'),
+  from: z.string(),
+  to: z.string().optional(),
+  content: z.string(),
+  timestamp: z.string(),
+});
+
+export const AgentStatusMessageSchema = z.object({
+  type: z.literal('agent_status'),
+  role: z.string(),
+  status: z.enum(['online', 'offline', 'working']),
+  currentBranch: z.string().optional(),
+  timestamp: z.string(),
+});
+
+export const TaskCreatedMessageSchema = z.object({
+  type: z.literal('task_created'),
+  role: z.string(),
+  taskFile: z.string(),
+  timestamp: z.string(),
+});
+
+export const PRCreatedMessageSchema = z.object({
+  type: z.literal('pr_created'),
+  role: z.string(),
+  prNumber: z.number(),
+  prUrl: z.string(),
+  timestamp: z.string(),
+});
+
+export const SystemMessageSchema = z.object({
+  type: z.literal('system'),
+  content: z.string(),
+  timestamp: z.string(),
+});
+
+export const MessageSchema = z.discriminatedUnion('type', [
+  ChatMessageSchema,
+  AgentStatusMessageSchema,
+  TaskCreatedMessageSchema,
+  PRCreatedMessageSchema,
+  SystemMessageSchema,
+]);
+
+export function validateMessage(data: unknown) {
+  return MessageSchema.parse(data);
+}


### PR DESCRIPTION
## Summary
Implements the complete WebSocket server infrastructure for agent-to-agent communication. This is Part 1 of 2 - the server is now ready for agents to connect to (Issue #2 will handle agent connections).

## Components Implemented

### 1. MinionsServer (`src/server/src/index.ts`)
- Express HTTP server with WebSocket support
- REST API endpoints:
  - `GET /api/health` - Health check
  - `GET /api/agents` - List connected agents
- WebSocket endpoint at `/ws`

### 2. WebSocketServer (`src/server/src/WebSocketServer.ts`)
- Accepts WebSocket connections at `/ws`
- Tracks connected clients with metadata (role, status, connectedAt)
- Handles connection/disconnection events
- Delegates message routing to MessageRouter
- Sends welcome message on connection

### 3. MessageRouter (`src/server/src/MessageRouter.ts`)
- Routes messages between agents
- **Unicast**: Send to specific agent by role (when `to` field is present)
- **Broadcast**: Send to all agents except sender
- Error handling for invalid messages
- Uses Zod validation for all messages

### 4. Message Validation (`src/server/src/schemas.ts`)
- Zod schemas for all message types:
  - ChatMessage
  - AgentStatusMessage
  - TaskCreatedMessage
  - PRCreatedMessage
  - SystemMessage
- Validates incoming messages against schemas
- Type-safe message handling

### 5. Configuration
- Added `serverPort` to Settings type and schema
- Default port: 3000
- Configurable via `minions.json`

## Usage

Start the server:
```bash
minions server
```

Connect with WebSocket client:
```bash
wscat -c ws://localhost:3000/ws
```

Check health:
```bash
curl http://localhost:3000/api/health
```

List connected agents:
```bash
curl http://localhost:3000/api/agents
```

## Testing
Manual testing can be done with:
1. `minions server` - verify server starts
2. `curl http://localhost:3000/api/health` - check health endpoint
3. `wscat -c ws://localhost:3000/ws` - connect WebSocket client
4. Send test messages - verify routing and validation

## Acceptance Criteria
- [x] Express HTTP server runs on configurable port
- [x] `/api/health` endpoint returns `{ status: 'ok' }`
- [x] `/api/agents` endpoint returns list of connected agents
- [x] WebSocket server accepts connections at `/ws`
- [x] Client connections tracked with role and status metadata
- [x] Message validation works for all message types
- [x] MessageRouter can route unicast messages (to specific agent)
- [x] MessageRouter can broadcast messages (to all agents)
- [x] `minions server` command starts the server
- [x] Server logs connections/disconnections
- [x] Invalid messages are rejected with error

## Next Steps
Issue #2 will connect agents to this server infrastructure.

Closes #11