### PR TITLE
Connect minion agents to WebSocket server

### DIFF
--- a/src/cli/src/agent/WebSocketClient.ts
+++ b/src/cli/src/agent/WebSocketClient.ts
@@ -1,0 +1,94 @@
+import WebSocket from 'ws';
+import type { Message } from '../../../core/messages.js';
+
+export class AgentWebSocketClient {
+  private ws: WebSocket | null = null;
+  private role: string;
+  private serverUrl: string;
+  private reconnectInterval: number = 5000;
+  private shouldReconnect: boolean = true;
+
+  constructor(role: string, serverUrl: string = 'ws://localhost:3000/ws') {
+    this.role = role;
+    this.serverUrl = serverUrl;
+  }
+
+  connect() {
+    this.ws = new WebSocket(this.serverUrl);
+
+    this.ws.on('open', () => {
+      console.log(`[${this.role}] Connected to server`);
+      this.sendStatus('online');
+    });
+
+    this.ws.on('message', (data) => {
+      try {
+        const message = JSON.parse(data.toString());
+        this.handleMessage(message);
+      } catch (error) {
+        console.error(`[${this.role}] Error parsing message:`, error);
+      }
+    });
+
+    this.ws.on('close', () => {
+      console.log(`[${this.role}] Disconnected from server`);
+      if (this.shouldReconnect) {
+        this.reconnect();
+      }
+    });
+
+    this.ws.on('error', (error) => {
+      console.error(`[${this.role}] WebSocket error:`, error.message);
+    });
+  }
+
+  private reconnect() {
+    setTimeout(() => {
+      console.log(`[${this.role}] Reconnecting...`);
+      this.connect();
+    }, this.reconnectInterval);
+  }
+
+  sendMessage(message: Message) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(message));
+    } else {
+      console.warn(`[${this.role}] Cannot send message - not connected`);
+    }
+  }
+
+  sendChat(to: string | undefined, content: string) {
+    this.sendMessage({
+      type: 'chat',
+      from: this.role,
+      to,
+      content,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  sendStatus(status: 'online' | 'offline' | 'working', currentBranch?: string) {
+    this.sendMessage({
+      type: 'agent_status',
+      role: this.role,
+      status,
+      currentBranch,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  private handleMessage(message: Message) {
+    // Handle incoming messages
+    // For now, just log them
+    console.log(`[${this.role}] Received message:`, JSON.stringify(message, null, 2));
+  }
+
+  disconnect() {
+    this.shouldReconnect = false;
+    if (this.ws) {
+      this.sendStatus('offline');
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements agent-to-server WebSocket connectivity, completing the communication infrastructure. Agents now auto-connect to the server and can communicate with each other.

**Part 2 of 2** - This builds on Issue #11 (server infrastructure).

## Components Implemented

### AgentWebSocketClient (`src/cli/src/agent/WebSocketClient.ts`)
A WebSocket client that agents use to connect to the server:

**Features:**
- Auto-connects to server on agent startup
- Sends `agent_status` message with role on connection (status: 'online')
- Sends `agent_status` on disconnect (status: 'offline')
- Supports sending chat messages (unicast or broadcast)
- Receives and logs messages from other agents
- Auto-reconnection with configurable interval (5s default)
- Graceful disconnect on agent shutdown
- Error handling for connection issues

**Methods:**
- `connect()` - Establish WebSocket connection
- `sendMessage(message)` - Send any message type
- `sendChat(to, content)` - Send chat message
- `sendStatus(status, branch?)` - Send status update
- `disconnect()` - Clean disconnect

### Integration with Start Command
Updated `src/cli/src/commands/start.ts`:
- Initializes WebSocketClient when `serverPort` is configured in `minions.json`
- Connects to `ws://localhost:{serverPort}/ws`
- Sets up cleanup handlers (SIGINT, SIGTERM, exit) to disconnect cleanly
- Logs connection status

## Usage

### 1. Configure Server Port
Add to `minions.json`:
```json
{
  "serverPort": 3000,
  // ... other settings
}
```

### 2. Start Server
```bash
minions server
```

### 3. Start Agents
```bash
minions start cao
minions start pm
minions start be-engineer
```

Agents will auto-connect to the server.

### 4. Verify Connections
```bash
curl http://localhost:3000/api/agents
```

Should show all connected agents with their roles and status.

## End-to-End Testing

**Setup:**
```bash
# Add "serverPort": 3000 to minions.json
minions server
```

**Test 1: Multiple Agent Connections**
```bash
# Terminal 1
minions start cao

# Terminal 2  
minions start pm

# Terminal 3
curl http://localhost:3000/api/agents
# Should show both cao and pm as online
```

**Test 2: Disconnection**
```bash
# Stop an agent (Ctrl+C)
# Check server logs - should show disconnect
# Check /api/agents - agent should be removed
```

**Test 3: Reconnection**
```bash
# Start agent: minions start qa
# Stop server (Ctrl+C)
# Check agent logs - should show reconnection attempts
# Restart server: minions server
# Agent should reconnect automatically
```

**Test 4: Message Flow**
- Server logs show agent_status messages on connect
- Server can route messages between agents
- Agents log received messages

## Acceptance Criteria
- [x] AgentWebSocketClient class implemented
- [x] Agents auto-connect to server when `serverPort` is configured
- [x] Agents send `agent_status` on connect (status: 'online')
- [x] Agents send `agent_status` on disconnect (status: 'offline')
- [x] Agents can send chat messages via WebSocket
- [x] Agents receive and log messages from other agents
- [x] Reconnection logic works if connection drops
- [x] Agent disconnects cleanly when stopped
- [x] Works gracefully when server is not running (retry)

## Next Steps
With server infrastructure (Issue #11) and agent connectivity (this issue) complete, the foundation is ready for:
- Web UI for chat interface
- Enhanced message handling in agents
- Task coordination between agents

Closes #12