### PR TITLE
Add connect.md startup instructions for agents

### DIFF
--- a/src/cli/src/commands/init.ts
+++ b/src/cli/src/commands/init.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { VALID_ROLES } from '../../../core/constants.js';
 import type { AgentRole, Repo, RoleConfig, Settings } from '../../../core/types.js';
 import { loadSettings } from '../lib/config.js';
-import { buildAgentPrompt } from '../lib/prompts.js';
+import { buildAgentPrompt, buildConnectFile } from '../lib/prompts.js';
 
 export async function init(): Promise<void> {
   const cwd = process.cwd();
@@ -35,6 +35,10 @@ export async function init(): Promise<void> {
     fs.writeFileSync(
       path.join(roleDir, 'CLAUDE.md'),
       buildAgentPrompt(role, settings.roles[role] || {}, cwd, settings.repos)
+    );
+    fs.writeFileSync(
+      path.join(roleDir, 'connect.md'),
+      buildConnectFile(role, settings.repos)
     );
     fs.copyFileSync(wsShSource, path.join(roleDir, 'ws.sh'));
     fs.chmodSync(path.join(roleDir, 'ws.sh'), 0o755);

--- a/src/cli/src/lib/prompts.ts
+++ b/src/cli/src/lib/prompts.ts
@@ -8,8 +8,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
 
 
-export function loadBaseTemplate() { 
+export function loadBaseTemplate() {
   return fs.readFileSync(path.join(TEMPLATES_DIR, `core.md`), 'utf-8');
+}
+
+export function loadConnectTemplate() {
+  return fs.readFileSync(path.join(TEMPLATES_DIR, `connect.md`), 'utf-8');
 }
 
 export function loadRoleTemplate(role: AgentRole): string {
@@ -64,6 +68,17 @@ export function buildAgentPrompt(
   if (instructions.project) {
     content += `\n${instructions.project}\n`;
   }
+
+  return content;
+}
+
+export function buildConnectFile(role: AgentRole, repos: Repo[] = []): string {
+  let content = loadConnectTemplate();
+
+  content = content.replaceAll('{{ROLE}}', role);
+
+  const repoLines = repos.map(r => `  - \`${r.path}/\``).join('\n');
+  content = content.replace('{{REPOS}}', repoLines);
 
   return content;
 }

--- a/src/cli/src/templates/connect.md
+++ b/src/cli/src/templates/connect.md
@@ -1,0 +1,39 @@
+# Startup Instructions
+
+Read and follow these steps carefully before doing anything else.
+
+## Step 1: Understand your environment
+
+- Your role is: **{{ROLE}}**
+- Your working directory is: `.minions/{{ROLE}}/`
+- You have your own **isolated clone** of the project repo(s) inside your working directory:
+{{REPOS}}
+- **IMPORTANT: All file reads, edits, git operations, and commands MUST happen within YOUR working directory. Do NOT operate on the parent workspace.**
+
+## Step 2: Connect to the team chat
+
+1. Make the WebSocket script executable:
+   ```bash
+   chmod +x ./ws.sh
+   ```
+
+2. Read `conversation.txt` to catch up on any prior messages:
+   ```bash
+   cat conversation.txt
+   ```
+
+3. Start listening for messages (foreground blocking call):
+   ```bash
+   ./ws.sh listen {{ROLE}}
+   ```
+
+## Step 3: Stay connected
+
+After receiving and processing every message:
+1. Respond using `./ws.sh chat {{ROLE}} <to> "your message"`
+2. **Immediately restart the listener:**
+   ```bash
+   ./ws.sh listen {{ROLE}}
+   ```
+
+**CRITICAL: The listener must ALWAYS be running. Run it as a foreground call (not background). After every send, restart it immediately. This is your primary loop.**

--- a/src/cli/src/templates/core.md
+++ b/src/cli/src/templates/core.md
@@ -1,20 +1,10 @@
 ## Working directory
 
-Under all circumstances, never navigate out of or alter files outside of your `.minion/<role>` directory. Inside `.minions` each of your team members each have their own repository. At the top level of the workspace there is the root project. Always make all changes and operations in context to your local working directory. 
+Your working directory is `.minions/<role>/` and contains your own **isolated clone** of the project repo(s). All file reads, edits, git operations, and commands MUST happen within your working directory. Do NOT operate on the parent workspace.
 
-## WebSocket Team Chat Communication
+## WebSocket Team Chat
 
-You communicate with other agents and the user via a WebSocket server. A `ws.sh` script is provided in your working directory — use it to listen and send messages.
-
-### Setup
-
-`ws.sh` is already present in your working directory and requires no sourcing. Make it executable at the start of your session:
-
-```bash
-chmod +x ./ws.sh
-```
-
-The script uses `${SERVER_PORT:-3000}` for the WebSocket URL and appends all messages to `conversation.txt` in your working directory.
+You communicate with other agents and the user via a WebSocket server using `ws.sh` in your working directory.
 
 ### Commands
 
@@ -29,9 +19,4 @@ The script uses `${SERVER_PORT:-3000}` for the WebSocket URL and appends all mes
 ./ws.sh chat <from> <to> "message content"
 ```
 
-### Workflow
-1. At the start of your session, read `conversation.txt` to catch up on any prior messages
-2. Run `./ws.sh listen <your-role>` as a **foreground blocking call** — it exits as soon as one non-system message arrives and appends it to `conversation.txt`
-3. Process the message and respond using `./ws.sh chat <from> <to> "message"` if needed
-4. **Immediately run `./ws.sh listen <your-role>` again** — do this after every send, without exception, even if you also reply in the Claude Code interface
-5. If the user sends a message from the interactive prompt, reply to them, then restart the listener
+The script uses `${SERVER_PORT:-3000}` for the WebSocket URL and appends all messages to `conversation.txt` in your working directory.


### PR DESCRIPTION
## Summary
- Adds a `connect.md` template that gets generated per agent during `minions init`, with role and repo info pre-filled
- Moves startup workflow (working directory orientation, WebSocket listener loop) out of `core.md` system prompt and into `connect.md`
- Users can now instruct agents to "read connect.md and follow the instructions" as their first message, turning startup into an active checklist rather than passive context

## Motivation
Agents consistently struggle with two things on startup:
1. Not realizing they have their own isolated repo clone (they try to work in the parent workspace)
2. Not keeping the WebSocket listener running as a foreground blocking call

Embedding these instructions in the system prompt wasn't effective — agents treat it as passive context. A dedicated file that agents actively read and execute is much more reliable.

## Test plan
- [ ] Run `minions init` and verify `connect.md` is generated in each `.minions/<role>/` directory
- [ ] Verify `connect.md` has the correct role name and repo paths filled in
- [ ] Verify `CLAUDE.md` / `core.md` no longer contains the full WebSocket workflow steps
- [ ] Start an agent, tell it to "read connect.md and follow the instructions", confirm it connects properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)