### PR TITLE
Rename server MessageRouter to ChatBroadcaster

### DIFF
--- a/src/server/src/ChatBroadcaster.ts
+++ b/src/server/src/ChatBroadcaster.ts
@@ -20,7 +20,7 @@ export class ChatBroadcaster {
     return this.chatHistory.slice(-capped);
   }
 
-  route(rawMessage: unknown, senderId: string) {
+  handle(rawMessage: unknown, senderId: string) {
     try {
       const message = validateMessage(rawMessage);
 

--- a/src/server/src/WebSocketServer.ts
+++ b/src/server/src/WebSocketServer.ts
@@ -6,18 +6,18 @@ import { v4 as uuidv4 } from 'uuid';
 export class WebSocketServer {
   private wss: WSServer;
   private clients: Map<string, ClientConnection>;
-  private router: ChatBroadcaster;
+  private broadcaster: ChatBroadcaster;
 
   constructor(server: Server) {
     this.wss = new WSServer({ server, path: '/ws' });
     this.clients = new Map();
-    this.router = new ChatBroadcaster(this.clients);
+    this.broadcaster = new ChatBroadcaster(this.clients);
 
     this.wss.on('connection', (ws) => this.handleConnection(ws));
   }
 
   getChatHistory(limit?: number) {
-    return this.router.getHistory(limit);
+    return this.broadcaster.getHistory(limit);
   }
 
   private handleConnection(ws: WebSocket) {
@@ -35,7 +35,7 @@ export class WebSocketServer {
       try {
         const rawData = data.toString();
         console.log(`Received message from ${clientId}: ${rawData.substring(0, 200)}`);
-        this.router.route(JSON.parse(rawData), clientId);
+        this.broadcaster.handle(JSON.parse(rawData), clientId);
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
         console.error(`Error handling message from ${clientId}:`, errorMsg);


### PR DESCRIPTION
The server and CLI both had a class named MessageRouter doing completely different things. Renamed the server class to ChatBroadcaster and updated the one import in WebSocketServer.ts. File renamed: src/server/src/MessageRouter.ts to src/server/src/ChatBroadcaster.ts. npm run typecheck passes.